### PR TITLE
Fix package name from ros_serail2wifi to ros_serial2wifi

### DIFF
--- a/chapt9/fishbot_ws/src/fishbot_bringup/launch/bringup.launch.py
+++ b/chapt9/fishbot_ws/src/fishbot_bringup/launch/bringup.launch.py
@@ -27,8 +27,8 @@ def generate_launch_description():
         output='screen'
     )
 
-    ros_serail2wifi =  launch_ros.actions.Node(
-        package='ros_serail2wifi',
+    ros_serial2wifi =  launch_ros.actions.Node(
+        package='ros_serial2wifi',
         executable='tcp_server',
         parameters=[{'serial_port': '/tmp/tty_laser'}],
         output='screen'


### PR DESCRIPTION
Previously, the code referred to ros_serail2wifi, which is incorrect and causes a package not found error when launching. The correct package name is ros_serial2wifi.

```bash
[ERROR] [launch]: Caught exception in launch:
"package 'ros_serail2wifi' not found"
```